### PR TITLE
Remaining homepage improvements

### DIFF
--- a/curate/views_api.py
+++ b/curate/views_api.py
@@ -180,8 +180,8 @@ def list_articles(request):
         impact = sum(map(F, impact_fields))
         queryset = Article.objects.annotate(impact=impact).order_by('-impact')
 
-    # Filters
-    filters = request.query_params.getlist('filter')
+    # Transparency ilters
+    transparency_filters = request.query_params.getlist('transparency')
 
     # A dict where the key is the expected query parameter and the value is a
     # queryset filter that will return the appropriate articles
@@ -195,10 +195,16 @@ def list_articles(request):
     }
 
     # Remove any invalid filters
-    valid_filters = [filter for filter in filters if filter in filter_expressions.keys()]
+    valid_filters = [filter for filter in transparency_filters if filter in filter_expressions.keys()]
 
     for filter in valid_filters:
         queryset = queryset.filter(filter_expressions[filter])
+
+    # Content type filter
+    content_type = request.query_params.get('content')
+    valid_content_types = ['ORIGINAL', 'REPLICATION', 'REPRODUCIBILITY', 'META_ANALYSIS']
+    if content_type and content_type in valid_content_types:
+        queryset = queryset.filter(article_type=getattr(Article, content_type))
 
     queryset = queryset.prefetch_related('commentaries', 'authors')
 

--- a/src/components/ArticleLI.jsx
+++ b/src/components/ArticleLI.jsx
@@ -35,6 +35,10 @@ const styles = {
   cardContent: {
     padding: 12
   },
+  createdDate: {
+    fontStyle: 'italic',
+    textAlign: 'right',
+  },
   title: {
     fontSize: 18,
     lineHeight: '20px',
@@ -138,9 +142,38 @@ class ArticleLI extends React.Component {
     	return text == null || text.length == 0
     }
 
+    created_at() {
+      const created = this.props.article.created
+
+      if (!created) {
+        return '-'
+      }
+
+      const date = new Date(created)
+      const months = {
+        0: 'January',
+        1: 'February',
+        2: 'March',
+        3: 'April',
+        4: 'May',
+        5: 'June',
+        6: 'July',
+        7: 'August',
+        8: 'September',
+        9: 'October',
+        10: 'November',
+        11: 'December'
+      }
+
+      const day = date.getDate()
+      const month = months[date.getMonth()]
+      const year = date.getFullYear()
+      return `Added ${month} ${day}, ${year}`
+    }
+
 	render() {
 		let {show_more, loading} = this.state
-    let { article, classes } = this.props;
+    let { article, classes, show_date } = this.props;
     let content_links = pick(article, ['pdf_url', 'pdf_downloads', 'pdf_citations', 'pdf_views',
 	       						   'html_url', 'html_views',
 	 	    					   'preprint_url', 'preprint_views', 'preprint_downloads',
@@ -158,6 +191,8 @@ class ArticleLI extends React.Component {
     let show_figures = article.key_figures || []
     let rd = pick(article, ['number_of_reps', 'original_study', 'target_effects', 'original_article_url'])
     const CC_ST = {paddingBottom: 12} // Fix for .MuiCardContent-root-325:last-child adding 24px padding-bottom
+    const created_at = this.created_at()
+
 		return (
 			<div className="ArticleCard">
 				<Card className={classes.card} raised>
@@ -182,6 +217,12 @@ class ArticleLI extends React.Component {
 			  				<Icon className={classes.moreIcon} fontSize="large">{show_more ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}</Icon>
 		  				</IconButton>
 	  				</div>
+
+            <div hidden={!show_date}>
+              <Typography className={classes.createdDate} component='div' color="textSecondary">
+                {created_at}
+              </Typography>
+            </div>
 
 	  				<div id="details" hidden={!show_more}>
 	  					<Typography className={classes.abstract}><TruncatedText text={article.abstract} maxLength={540} fontSize={12} /></Typography>

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -108,7 +108,7 @@ class ArticleList extends React.Component {
   }
 
   render() {
-    let {articles, classes, user_session} = this.props
+    let {articles, classes, show_date, user_session} = this.props
     let {
       edit_article_modal_open,
       editing_article_id,
@@ -149,6 +149,7 @@ class ArticleList extends React.Component {
                 <StyledArticleWithActions key={a.id}
                   article={a}
                   user_session={user_session}
+                  show_date={show_date}
                   onEdit={this.handle_edit}
                   onDelete={this.handle_delete}
                   onUpdate={this.article_updated}
@@ -243,7 +244,7 @@ class ArticleWithActions extends React.Component {
   }
 
   render() {
-    let { article, classes } = this.props
+    let { article, classes, show_date } = this.props
     const admin = this.props.user_session.admin
     const editable = this.editable()
     const user_has_associated_author = this.user_has_associated_author()
@@ -263,7 +264,9 @@ class ArticleWithActions extends React.Component {
           <ArticleLI article={article}
             admin={false}
             onFetchedArticleDetails={this.got_article_details}
-            onFigureClick={this.show_figure} />
+            onFigureClick={this.show_figure}
+            show_date={show_date}
+          />
         </div>
         <div className="ArticleLeftActions">
           <span className="ActionButton">

--- a/src/components/HomePageFilter.jsx
+++ b/src/components/HomePageFilter.jsx
@@ -1,0 +1,227 @@
+import React from 'react';
+
+import { filter, includes, xor } from 'lodash'
+
+import {
+  Button,
+  Checkbox,
+  Chip,
+  ClickAwayListener,
+  FormControlLabel,
+  FormGroup,
+  Grid,
+  Icon,
+  Paper,
+  Typography,
+} from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+
+import C from '../constants/constants';
+
+import TransparencyIcon from '../components/shared/TransparencyIcon.jsx';
+
+const styles = theme => ({
+  menuRoot: {
+    position: 'relative'
+  },
+  menu: {
+    position: 'absolute',
+    top: '4rem',
+    left: 0,
+    zIndex: 10,
+  },
+  menuTitle: {
+    fontSize: 16,
+  },
+  transparencyGroup: {
+    padding: 2*theme.spacing.unit,
+    whiteSpace: 'nowrap',
+  },
+  filterChips: {
+    paddingTop: theme.spacing.unit,
+  },
+  filterCheckbox: {
+    paddingLeft: theme.spacing.unit
+  },
+})
+
+class HomePageFilter extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      menu_open: false,
+      menu_content_filter: null,
+      menu_transparency_filters: [],
+    };
+
+    this.filter_options = [
+      { field: 'registered_report', icon: 'prereg', label: 'Registered Report'},
+      { field: 'open_materials', icon: 'materials', label: 'Public study materials'},
+      { field: 'open_data', icon: 'data', label: 'Public data'},
+      { field: 'open_code', icon: 'code', label: 'Public code'},
+      { field: 'reporting_standards', icon: 'repstd', label: 'Reporting standard compliance'},
+    ]
+
+    const content_filter_ids = ['ORIGINAL', 'REPLICATION', 'REPRODUCIBILITY', 'META_ANALYSIS']
+    this.content_filter_options = filter(C.ARTICLE_TYPES, type => includes(content_filter_ids, type.id))
+
+    this.close_menu = this.close_menu.bind(this)
+    this.delete_filter = this.delete_filter.bind(this)
+    this.filter_checked = this.filter_checked.bind(this)
+    this.content_filter_checked = this.content_filter_checked.bind(this)
+    this.handle_menu_click = this.handle_menu_click.bind(this)
+    this.clear_all_filters = this.clear_all_filters.bind(this)
+    this.update_filters = this.update_filters.bind(this)
+    this.update_content_filter = this.update_content_filter.bind(this)
+    this.set_filters = this.set_filters.bind(this)
+  }
+
+  open_menu() {
+    const { content_filter, transparency_filters } = this.props
+    this.setState({ menu_open: true, menu_transparency_filters: transparency_filters, menu_content_filter: content_filter })
+  }
+
+  close_menu() {
+    this.setState({ menu_open: false })
+  }
+
+  clear_all_filters() {
+    this.setState({ menu_transparency_filters: [], menu_content_filter: null })
+  }
+
+  delete_filter(filter_field) {
+    let { content_filter, transparency_filters, onFilterUpdate } = this.props
+    onFilterUpdate({ transparency_filters: transparency_filters.filter(field => field !== filter_field), content_filter })
+  }
+
+  filter_checked(field) {
+    return includes(this.state.menu_transparency_filters, field)
+  }
+
+  content_filter_checked(field) {
+    return this.state.menu_content_filter === field
+  }
+
+  update_filters(field) {
+    let { menu_transparency_filters } = this.state
+    this.setState({ menu_transparency_filters: xor(menu_transparency_filters, [field]) })
+  }
+
+  update_content_filter(menu_content_filter) {
+    if (this.state.menu_content_filter === menu_content_filter) {
+      // Clear the checkbox
+      this.setState({ menu_content_filter: null })
+    } else {
+      this.setState({ menu_content_filter })
+    }
+  }
+
+  set_filters(field, event) {
+    const { onFilterUpdate }  = this.props
+    onFilterUpdate({
+      transparency_filters: this.state.menu_transparency_filters,
+      content_filter: this.state.menu_content_filter
+    })
+    this.close_menu()
+  }
+
+  handle_menu_click() {
+    if (this.state.menu_open) {
+      this.close_menu()
+    } else {
+      this.open_menu()
+    }
+  }
+
+  render() {
+    let { menu_open } = this.state
+    let { classes, transparency_filters } = this.props
+
+    return (
+      <Grid className={classes.menuRoot}>
+        <ClickAwayListener onClickAway={this.close_menu}>
+          <div>
+            <Button
+              onClick={this.handle_menu_click}
+              size="large"
+            >
+              <Icon>filter_list</Icon>
+                Filter
+            </Button>
+              { menu_open ? (
+                <Paper className={classes.menu}>
+                  <div className={classes.transparencyGroup}>
+                    <Grid container wrap="nowrap">
+                      <Grid item xs={6}>
+                        <Typography className={classes.menuTitle}>Transparency</Typography>
+                        <FormGroup>
+                            { this.filter_options.map(filter =>
+                              <div key={filter.field}>
+                                <FormControlLabel
+                                  control={
+                                    <Checkbox
+                                      checked={this.filter_checked(filter.field)}
+                                      onChange={this.update_filters.bind(this, filter.field)}
+                                      value={filter.field}/>
+                                  }
+                                  label={
+                                    <div style={{display: 'flex', alignItems: 'center'}}>
+                                      <TransparencyIcon tt={{icon: filter.icon}} size={25} />
+                                      <span className={classes.filterCheckbox}>{filter.label}</span>
+                                    </div>
+                                  }
+                                />
+                              </div>
+                            ) }
+                        </FormGroup>
+                      </Grid>
+
+                      <Grid item xs={6} style={{marginLeft: '4rem'}}>
+                        <Typography className={classes.menuTitle}>Content Type</Typography>
+                        <FormGroup>
+                            { this.content_filter_options.map(filter =>
+                              <div key={filter.id}>
+                                <FormControlLabel
+                                  control={
+                                    <Checkbox
+                                      checked={this.content_filter_checked(filter.id)}
+                                      onChange={this.update_content_filter.bind(this, filter.id)}
+                                      value={filter.id}
+                                    />
+                                  }
+                                  label={filter.label}
+                                />
+                              </div>
+                            ) }
+                        </FormGroup>
+                      </Grid>
+                    </Grid>
+                  </div>
+
+                  <Grid container justify="flex-end">
+                    <Button onClick={this.clear_all_filters}>Clear All Filters</Button>
+                    <Button variant="contained" onClick={this.set_filters} style={{float: 'right', margin: '1rem'}}>Apply</Button>
+                  </Grid>
+
+                </Paper>
+              ) : null}
+          </div>
+        </ClickAwayListener>
+        <div className={classes.filterChips}>
+            { this.filter_options.map(filter => {
+                if (includes(transparency_filters, filter.field)) {
+                  return <Chip
+                          label={<TransparencyIcon tt={{icon: filter.icon}} size={25}/>}
+                          key={filter.field}
+                          onDelete={this.delete_filter.bind(this, filter.field)}
+                        />
+                }
+            })
+            }
+        </div>
+      </Grid>
+    )
+  }
+}
+
+export default withStyles(styles)(HomePageFilter)

--- a/src/pages/Recent.jsx
+++ b/src/pages/Recent.jsx
@@ -155,6 +155,7 @@ class Home extends React.PureComponent {
                     articles={articles}
                     onArticlesUpdated={this.update_articles}
                     user_session={this.props.user_session}
+                    show_date={true}
                   />
 
                   { articles.length === 0 ? null :


### PR DESCRIPTION
I've added the content filtering and the 'Added at ...' text to the bottom right of the article cards on the home page.

@eplebel I think the only outstanding things are:

* the colours behind the content type filter labels — the colours I found associated with the different article types are a bit different (see [here](https://github.com/ScienceCommons/curate_science/blob/master/src/constants/constants.js#L19)), there's none set for the reanalyses and the colour for reproducibility looks like the one that's used for reanalyses in your mockup. I'm not sure if these are set somewhere else or if they haven't been locked down yet.

* the transparency filter for 'Preregistered design + analysis'. This and 'Registered report' are mutually exclusive, right? Is the expected behaviour that selecting one would clear the other? I think it would be a little unintuitive as all of the other transparency filters can be combined. Maybe there should be a separate filter for preregistration type? Or maybe that's a discussion for another day! :smile:

Let me know what you think and if there's anything else I'm missing.