### PR TITLE
Abstract formatting, Title Formatting, Author Name formatting

### DIFF
--- a/src/components/ArticleEditor.jsx
+++ b/src/components/ArticleEditor.jsx
@@ -44,7 +44,7 @@ import { makeStyles } from '@material-ui/styles';
 import { withStyles } from '@material-ui/core/styles';
 import { clone, debounce, find, get, includes, set, truncate } from 'lodash'
 import {json_api_req, simple_api_req, unspecified, summarize_api_errors} from '../util/util.jsx'
-import {retrieve_authors,authorFormatting} from '../components/curateform/DOILookup.jsx'
+import {retrieve_authors,retrieve_title, retrieve_abstract} from '../components/curateform/DOILookup.jsx'
 const Transition = React.forwardRef((props, ref) => {
   return <Slide direction="up" {...props} ref={ref}/>;
 })
@@ -892,7 +892,7 @@ class ArticleEditor extends React.Component {
 
         if (!res.success) return
         const data = res.data
-        form.title = data.title[0]
+        form.title = retrieve_title(data.title[0], data.subtitle[0])
         form.author_list = retrieve_authors(data.author)
         form.pdf_citations = data['is-referenced-by-count']
         form.journal = get(data, ['container-title', 0])
@@ -902,6 +902,9 @@ class ArticleEditor extends React.Component {
         }
         if (form.year === null || form.year === undefined || form.year == ""){
           form.year = get(data, ['issued', 'date-parts', 0, 0])
+        }
+        if (data['abstract'] !== null && data['abstract'] !== undefined  && data['abstract'] !== "") {
+          form.abstract = retrieve_abstract(data['abstract'])
         }
         this.setState({form})
       })

--- a/src/components/curateform/DOILookup.jsx
+++ b/src/components/curateform/DOILookup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {TextField, Button, Icon, Typography, Menu, Grid, InputLabel,
 	FormControl, Select, OutlinedInput, InputBase} from '@material-ui/core';
-
+import { upperFirst } from 'lodash';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -144,16 +144,46 @@ DOILookup.defaultProps = {
     value: ''
 };
 export function retrieve_authors(authors) {
+		// number of authors
+	  const authorsLen = authors.length;
 
-    const authorsLen = authors.length;
 
+    function countUpperCase(name) {
+        let capitalCount = 0;
+        name.split("")
+            .forEach(function(letter) {
+                if (letter === letter.toUpperCase() && letter !== letter.toLowerCase()) {
+                    capitalCount += 1;
+                }
+            })
+        return capitalCount;
+
+    }
     // creating formatted list of authors (first initials + " " + last name)
     function formattedAuthor(authorName) {
-        let authInitials = authorName['given'].split(' ')
-            .map(name => name[0])
-            .join("");
-        let authorFamilyName = authorName['family'];
-        return `${authInitials} ${authorFamilyName}`
+        // family name and given name are not available
+        if (authorName['family'] === undefined && authorName['given'] ===
+            undefined) {
+            // return 'name' field if not missing, otherwise throw error
+            if (authorName['name'] !== undefined) {
+                return upperFirst(authorName['name'])
+            } else {
+                throw "Error: Cannot extract author information"
+            }
+            // if family name or given name are available
+        } else {
+            let authInitials = authorName['given'].split(' ')
+                .map(name => upperFirst(name[0]))
+                .join("");
+            let authorFamilyName = authorName['family'];
+
+            // Reformat if family name is all capital OR if there's no capitals in the family name
+            if (countUpperCase(authorFamilyName) === 0 || countUpperCase(
+                    authorFamilyName) === authorFamilyName.length) {
+                authorFamilyName = upperFirst(authorFamilyName.toLowerCase())
+            }
+            return `${authInitials} ${authorFamilyName}`
+        }
     }
 
     // creating author string (1 author, 2 authors, >2 authors)
@@ -162,7 +192,7 @@ export function retrieve_authors(authors) {
     let lastAuthor = authors.slice(-1)[0] // last author
 
     let fullAuthString = ""
-
+		// conditional formatting for instances in which there is
     if (authorsLen == 1) {
         fullAuthString = formattedAuthor(lastAuthor)
     } else if (authorsLen == 2) {
@@ -174,7 +204,7 @@ export function retrieve_authors(authors) {
 
         })
 
-        if (authorsLen > 6) {
+        if (authorsLen > 7) {
             fullAuthString += `... , `
         }
 
@@ -184,5 +214,36 @@ export function retrieve_authors(authors) {
     return fullAuthString
 
 };
+
+
+export function retrieve_title(title, subtitle) {
+
+    function removePeriods(title) {
+        // replace '.:' with '.'
+        let newTitle = title.replace(/\.:/g, '.')
+
+        // if '.' is at end, remove last character of title
+        return (newTitle.slice(-1) === "." ? newTitle.slice(0, -1) : newTitle)
+    }
+
+    let fullTitle = ''
+    if (subtitle === null || subtitle === undefined || subtitle === "") {
+        fullTitle = upperFirst(title.toLowerCase());
+    } else {
+        fullTitle =
+            `${upperFirst(title.toLowerCase())}: ${upperFirst(subtitle.toLowerCase())}`;
+    }
+
+    return removePeriods(fullTitle)
+};
+
+
+
+export function retrieve_abstract(abstract) {
+    let abstractHtml = document.createElement('html');
+    abstractHtml.innerHTML = abstract
+    return abstractHtml.textContent.trim() || abstractHtml.innerText.trim()
+};
+
 
 export default withStyles(styles)(DOILookup);


### PR DESCRIPTION
Created function to retrieve and format abstracts. Removes html tags and trailing whitespace.

Created function to retrieve title+subtitle and format (removing period at end up subtitle, adding colon only when there is no period between title/subtitle).

modified author formatting function to use different field if "family name" and "given name" fields are missing. Added code to lowercase all letters in family name except first letter if: all letters are capital OR there are no capital letters in the family name. Function now throws error if both attempts to extract author name fail.

Fixed error with author formatting returning ", ... ," between 6th and 7th authors when there are 7 authors.