### PR TITLE
fixed small glitch in title function

### DIFF
--- a/src/components/curateform/DOILookup.jsx
+++ b/src/components/curateform/DOILookup.jsx
@@ -231,7 +231,7 @@ export function retrieve_title(title, subtitle) {
 
         let fullTitle = ''
         if (subtitle === null || subtitle === undefined || subtitle === "" ||
-            fullTitle.includes(":")) {
+            title.includes(":")) {
             fullTitle = upperFirst(title.toLowerCase());
 
         } else {


### PR DESCRIPTION
should now retrieve subtitle only if title does not include ":"