### PR TITLE
Reduce minimum viewport breakpoint from 1920px to 1500px

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,15 @@ const theme = createMuiTheme({
             fontSize: 13
         }
     }
+  },
+  breakpoints: {
+    values: {
+        xs: 0,
+        sm: 450,
+        md: 600,
+        lg: 1200,
+        xl: 1500
+    }
   }
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,15 +73,6 @@ const theme = createMuiTheme({
             fontSize: 13
         }
     }
-  },
-  breakpoints: {
-    values: {
-        xs: 0,
-        sm: 450,
-        md: 600,
-        lg: 1200,
-        xl: 1500
-    }
   }
 });
 

--- a/src/components/ViewEmbeddedContentButton.jsx
+++ b/src/components/ViewEmbeddedContentButton.jsx
@@ -87,7 +87,7 @@ export default function ViewEmbeddedContentButton({ iconStyle, mediaType, style,
     }
 
     // If the screen size is less than the XL breakpoint, don't show the embedded content button
-    const lessThanXl = useMediaQuery(theme => theme.breakpoints.down('lg'))
+    const lessThanXl = useMediaQuery('(max-width:1499px)')
     if (lessThanXl) return null
 
     if (!url_is_valid(url, mediaType)) return null


### PR DESCRIPTION
> optimize minimum viewport breakpoint width to enable full-screen mode: Reduce it to 1500px (from current 1900px), which is still sufficient to allow a wide-enough full-text embed viewer right-panel. So this means, full-screen icons (for valid embedabble full-text links) should be displayed if viewport >1500px (rather than current 1900px) 20 points

in the full-screen mode enhancements #95 

Below screenshots of the content in the responsive design mode
![Screenshot from 2020-05-04 22-18-56](https://user-images.githubusercontent.com/43213967/81012708-4e4b9b00-8e5a-11ea-8035-f20f32174986.png)
![Screenshot from 2020-05-04 22-20-06](https://user-images.githubusercontent.com/43213967/81012713-4f7cc800-8e5a-11ea-8e3e-fb6885207f70.png)
![Screenshot from 2020-05-04 22-20-17](https://user-images.githubusercontent.com/43213967/81012714-50155e80-8e5a-11ea-986c-c51d044b4561.png)
![Screenshot from 2020-05-04 22-20-29](https://user-images.githubusercontent.com/43213967/81012715-50adf500-8e5a-11ea-88c0-149aab928fae.png)
