### PR TITLE
Add distill.pub HTML as a new embeddable content in the full-screen mode

### DIFF
--- a/src/components/ViewEmbeddedContentButton.jsx
+++ b/src/components/ViewEmbeddedContentButton.jsx
@@ -40,8 +40,9 @@ function pdf_url_is_valid(url) {
 
 
 function html_url_is_valid(url) {
+    const valid_urls = ['github.io', 'distill.pub']
     if (includes(url, 'frontiersin.org/articles') && endsWith(url, 'full')) return true
-    if (includes(url, 'github.io')) return true
+    if (url_contains(url, valid_urls)) return true
     return endsWith(url, '.html')
 }
 


### PR DESCRIPTION
Update in the "more substantive display-based improvements #105"

>  Add new supported HTML embedded content: 
    Add Distill.pub HTML articles to supported full-screen HTML links (which feature some of the most delicious/impressive interactive charts in the world!)! Example URLs that should display an full-screen icon: https://distill.pub/2019/computing-receptive-fields/ ; https://distill.pub/2020/attribution-baselines/


  