### PR TITLE
Change the default text of the sort button on the recent page

### DIFF
--- a/src/components/SortArticlesButton.jsx
+++ b/src/components/SortArticlesButton.jsx
@@ -85,7 +85,7 @@ class SortBy extends React.PureComponent {
               style={{color: "#999"}}
             >
               <Icon className={classes.leftIcon}>sort</Icon>
-              Sort by { sorted_by ? <span>: { sorted_by }</span> : null }
+              Sort by
             </Button>
               { menu_open ? (
                 <Paper className={classes.menu}>

--- a/src/pages/Recent.jsx
+++ b/src/pages/Recent.jsx
@@ -25,7 +25,7 @@ class Home extends React.PureComponent {
       articles_loading: true,
       content_filters: [],
       transparency_filters: ['open_code', 'open_data', 'open_materials'],
-      sort_by: 'created',
+      sort_by: null,
       more_articles: true,
       current_page: 1,
     };


### PR DESCRIPTION
Update in the  "minor esthetic/stylistic tweaks #96"

> Recent page: Update text from "SORT BY: NEWEST FIRST" simply to "SORT BY" (just like on search results page, e.g. https://curatescience.org/app/search/?q=disgust) 5 points