### PR TITLE
Remove -- in the empty abstracts after truncation by not rendering them.

### DIFF
--- a/src/components/ArticleContent.jsx
+++ b/src/components/ArticleContent.jsx
@@ -324,11 +324,13 @@ class ArticleContent extends React.PureComponent {
 
         <div id="details" hidden={!is_expanded} style={{ paddingBottom: '0.75rem' }}>
           <Typography className={classes.abstract} variant="body2">
-            { (is_article_page) 
-              ? <span>{article.abstract}</span>
-              : (article.abstract == null || article.abstract.length == 0)
-              ? null
-              : <TruncatedText text={article.abstract} maxLength={540} fontSize={12} />
+            { (is_article_page) ? 
+            <span>{article.abstract}</span>
+              : 
+                (article.abstract == null || article.abstract.length == 0) ?
+                null
+                  : 
+                    <TruncatedText text={article.abstract} maxLength={540} fontSize={12} />
             }
           </Typography>
           <ArticleKeywords keywords={article.keywords} />

--- a/src/components/ArticleContent.jsx
+++ b/src/components/ArticleContent.jsx
@@ -324,10 +324,11 @@ class ArticleContent extends React.PureComponent {
 
         <div id="details" hidden={!is_expanded} style={{ paddingBottom: '0.75rem' }}>
           <Typography className={classes.abstract} variant="body2">
-            { is_article_page ?
-            <span>{article.abstract}</span>
-                :
-                  <TruncatedText text={article.abstract} maxLength={540} fontSize={12} />
+            { (is_article_page) 
+              ? <span>{article.abstract}</span>
+              : (article.abstract == null || article.abstract.length == 0)
+              ? null
+              : <TruncatedText text={article.abstract} maxLength={540} fontSize={12} />
             }
           </Typography>
           <ArticleKeywords keywords={article.keywords} />


### PR DESCRIPTION
Fix in the minor esthetic/stylistic tweaks #96 

> fix empty abstract issue, which incorrectly shows "-- " instead of just showing nothing, not even a row (e.g., https://curate-science-staging-2.appspot.com/app/author/john-bargh, expand the only article card; interestingly, this seems to be correctly working on the article page, i.e., https://curate-science-staging-2.appspot.com/app/article/301, notice the "--" are correctly not displayed) 

i could place a similar fix in the source, TruncatedText, but i didn't because it's shared with TransparencyBadge component and i wanted to avoid any unpredicted behavior. we can consider it later 