### PR TITLE
Show edit button when user hovers over author information section.

### DIFF
--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -40,6 +40,7 @@ const styles = theme => ({
         maxWidth: C.CARD_COL_WIDTH + 'px'
     },
     authorEditButton: {
+        visibility: 'hidden',
         position: 'absolute',
         top: 0,
         right: 0
@@ -71,6 +72,12 @@ const styles = theme => ({
         paddingBottom: theme.spacing(1),
         color: '#DCDCDC',
     },
+    authorInformation: {
+        position: 'relative',
+        '&:hover $authorEditButton': {
+            visibility: 'visible'
+        }
+    }
 })
 
 class AuthorPage extends React.Component {
@@ -381,7 +388,7 @@ class AuthorPage extends React.Component {
                         {
                             !embedded ?
                             <div className={classes.cardColumn}>
-                                <div style={{position: 'relative'}}>
+                                <div className={classes.authorInformation}>
                                     <span hidden={!editable}>
                                         <Button variant="outlined" color="secondary"
                                             className={classes.authorEditButton}


### PR DESCRIPTION
Improvement in author page improvements #103 
 - for author information section, show Edit button only (with title "Edit Author Information") when user hovers over author information section (rather than always displayed)