### PR TITLE
Author page three dot actions menu #103

### DIFF
--- a/src/components/AuthorPageActions.jsx
+++ b/src/components/AuthorPageActions.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Button, 
+    Icon,
+    Tooltip,
+} from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+    menuIcon: {
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
+        float: 'right'
+    },
+    menu: {
+        marginLeft: '10px',  
+        marginTop: '5px'
+    },
+    menuItem: {
+        margin: 0,
+        padding: 0,
+        border: 'solid',
+        borderColor: '#999',
+        borderWidth: '1.5px',
+    }          
+}));
+
+export default function LongMenu() {
+    const classes = useStyles()
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
+
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const ActionButton = ({ iconLeft, iconRight, label, color }) => {
+        color = color || 'primary'
+        return (
+            <Button
+            variant="outlined"
+            size="medium"
+            color={color}
+            style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'flex-start',
+                padding: '0.5rem 0.5rem',
+                border: 'none',
+                color: '#999',
+            }}
+            >
+                <Icon>{iconLeft}</Icon>
+                <span style={{ marginLeft: '0.5rem' }}>
+                    {label}
+                </span>
+                    { iconRight === null ? null :
+                        <Tooltip title="Link an article to your author page that is already in our database (for example, an article that has already been added by one of your co-authors)."> 
+                            <Icon style={{marginLeft:'0.6rem'}}>{iconRight}</Icon>
+                        </Tooltip>
+                    }
+            </Button>
+        )
+    }
+
+    return (
+        <span>
+            <IconButton
+                className={classes.menuIcon}
+                aria-label="more"
+                aria-controls="long-menu"
+                aria-haspopup="true"
+                onClick={handleClick}
+                style={{minWidth: 0, color: '#CCC' }}
+            >
+            <MoreVertIcon />
+            </IconButton>
+            <Menu
+                id="long-menu"
+                anchorEl={anchorEl}
+                anchorOrigin={{horizontal: 'right', vertical: 'top'}}
+                getContentAnchorEl = {null}
+                keepMounted
+                open={open}
+                onClose={handleClose}
+                className={classes.menu}
+                MenuListProps={{ style: {padding: 0}}}
+            >
+                <MenuItem key='Add article' onClick={handleClose} className={classes.menuItem}>
+                    <ActionButton iconLeft='add' iconRight={null} label='Add article' color='default'/>
+                </MenuItem>
+
+                <MenuItem key='Link existing article' onClick={handleClose} className={classes.menuItem}>
+                    <ActionButton iconLeft='link' iconRight='info' label='Link existing article' color='default'/>
+                </MenuItem>
+            </Menu>
+        </span>
+    );
+}

--- a/src/components/AuthorPageActions.jsx
+++ b/src/components/AuthorPageActions.jsx
@@ -1,13 +1,19 @@
-import React from 'react';
+//import React from 'react';
+import React, { useState, useEffect  } from 'react';
 import { Button, 
     Icon,
     Tooltip,
+    Popover,
 } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import { makeStyles } from '@material-ui/core/styles';
+import { json_api_req, randomId, send_height_to_parent } from '../util/util.jsx'
+import C from '../constants/constants';
+//import { get, includes, isEmpty } from 'lodash'
+import ArticleSelector from './curateform/ArticleSelector.jsx';
 
 const useStyles = makeStyles(theme => ({
     menuIcon: {
@@ -28,19 +34,29 @@ const useStyles = makeStyles(theme => ({
     }          
 }));
 
-export default function LongMenu() {
+export default function LongMenu({articlesIds, addArticle, linkArticle}) {
     const classes = useStyles()
-    const [anchorEl, setAnchorEl] = React.useState(null);
-    const open = Boolean(anchorEl);
+    const [anchorElMenu, setAnchorElMenu] = React.useState(null);
+    const [anchorElPopper, setAnchorElPopper] = React.useState(null);
 
-    const handleClick = (event) => {
-        setAnchorEl(event.currentTarget);
+    const openMenu = Boolean(anchorElMenu);
+    const openPopper = Boolean(anchorElPopper);
+
+    const handleClickMenu = (event) => {
+        setAnchorElMenu(event.currentTarget);
     };
 
-    const handleClose = () => {
-        setAnchorEl(null);
+    const handleCloseMenu = () => {
+        setAnchorElMenu(null);
     };
 
+    const handleClickPopper = (event) => {
+        setAnchorElPopper(event.currentTarget);
+    };
+
+    const handleClosePopper = () => {
+        setAnchorElPopper(null);
+    };
     const ActionButton = ({ iconLeft, iconRight, label, color }) => {
         color = color || 'primary'
         return (
@@ -77,30 +93,48 @@ export default function LongMenu() {
                 aria-label="more"
                 aria-controls="long-menu"
                 aria-haspopup="true"
-                onClick={handleClick}
+                onClick={handleClickMenu}
                 style={{minWidth: 0, color: '#CCC' }}
             >
             <MoreVertIcon />
             </IconButton>
             <Menu
                 id="long-menu"
-                anchorEl={anchorEl}
+                anchorEl={anchorElMenu}
                 anchorOrigin={{horizontal: 'right', vertical: 'top'}}
                 getContentAnchorEl = {null}
                 keepMounted
-                open={open}
-                onClose={handleClose}
+                open={openMenu}
+                onClose={handleCloseMenu}
                 className={classes.menu}
                 MenuListProps={{ style: {padding: 0}}}
             >
-                <MenuItem key='Add article' onClick={handleClose} className={classes.menuItem}>
+                <MenuItem key='Add article' onClick={() => {handleCloseMenu(); addArticle()}} className={classes.menuItem}>
                     <ActionButton iconLeft='add' iconRight={null} label='Add article' color='default'/>
                 </MenuItem>
 
-                <MenuItem key='Link existing article' onClick={handleClose} className={classes.menuItem}>
+                <MenuItem key='Link existing article' onClick={handleClickPopper} className={classes.menuItem}>
                     <ActionButton iconLeft='link' iconRight='info' label='Link existing article' color='default'/>
                 </MenuItem>
             </Menu>
+            <Popover
+        id="add_preexisting_popper"
+        open={openPopper}
+        anchorEl={anchorElPopper}
+        onClose={handleClosePopper}
+        anchorOrigin={{
+            vertical: 'bottom',
+                horizontal: 'left',
+        }}
+        transformOrigin={{
+            vertical: 'top',
+                horizontal: 'left',
+        }}
+        >
+            <div style={{width: "400px", height: "250px", padding: 14 }}>
+                <ArticleSelector onChange={linkArticle} author_articles={articlesIds} />
+            </div>
+        </Popover>
         </span>
     );
 }

--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -97,7 +97,10 @@ const styles = theme => ({
         border: 'solid',
         borderColor: '#999',
         borderWidth: '1.5px',
-    }          
+    },          
+    actions: {
+        paddingTop: theme.spacing(5),
+    }
 })
 
 const ActionButton = ({ iconLeft, iconRight, label, color }) => {
@@ -540,8 +543,10 @@ class AuthorPage extends React.Component {
                                     </Typography>
                                     <AuthorLinks links={author.profile_urls} />
                                 </div>
-                                    {search_filter}
-                                    {long_menu}
+                                    <div className={classes.actions}>
+                                        {search_filter}
+                                        {long_menu}
+                                    </div>
                                 </div>
                                 :
                                 <Grid container alignItems="center" justify="space-between">

--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -24,6 +24,7 @@ import Loader from '../components/shared/Loader.jsx';
 import AuthorLinks from '../components/AuthorLinks.jsx';
 import LabeledBox from '../components/shared/LabeledBox.jsx';
 import ArticleSelector from '../components/curateform/ArticleSelector.jsx';
+import LongMenu from '../components/AuthorPageActions.jsx';
 
 import { includes, merge } from 'lodash'
 
@@ -80,13 +81,14 @@ const styles = theme => ({
             visibility: 'visible'
         }
     },
-  actionMenu: {
-      paddingTop: theme.spacing(1),
-      paddingBottom: theme.spacing(1),
-      margin: 0,
-      position: 'absolute',
-      right: (C.COL_WIDTH - C.CARD_COL_WIDTH)/2,
-  }
+    actionIcon: {
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
+        float: 'right'
+    },
+    actionMenu: {
+        marginLeft: '10px'    
+    }
 })
 
 class AuthorPage extends React.Component {
@@ -405,10 +407,10 @@ class AuthorPage extends React.Component {
         const long_menu = (
             <span hidden={!editable}>
                 <IconButton 
-                    className={classes.actionMenu}
+                    className={classes.actionIcon}
                     aria-label="more"
                     aria-controls="long-menu"
-                     aria-haspopup="true"
+                    aria-haspopup="true"
                     onClick={this.open_action_list}
                 >
                 <MoreVertIcon />
@@ -419,15 +421,9 @@ class AuthorPage extends React.Component {
                     anchorEl={actionAnchorEl}
                     anchorOrigin={{horizontal: 'right', vertical: 'top'}}
                     onClose={this.close_action_list}
-                    PaperProps={{
-                        style: {
-                        maxHeight: ITEM_HEIGHT * 4.5,
-                        width: '20ch',
-                    },
-                    }}
+                    className={classes.actionMenu}
+                    getContentAnchorEl={null}
                 >
-                    <MenuItem key={'Add article'} onClick={this.create_new_article}>Add article</MenuItem>
-                    <MenuItem key={'Link existing article'} onClick={this.open_preexisting_popper}>Link existing article</MenuItem>
                 </Menu>
             </span>
         )
@@ -460,7 +456,7 @@ class AuthorPage extends React.Component {
                                     <AuthorLinks links={author.profile_urls} />
                                 </div>
                                     {search_filter}
-                                    {long_menu}
+                                    <LongMenu/>
                                 </div>
                                 :
                                 <Grid container alignItems="center" justify="space-between">

--- a/src/pages/AuthorPage.jsx
+++ b/src/pages/AuthorPage.jsx
@@ -190,7 +190,6 @@ class AuthorPage extends React.Component {
         let {match} = this.props
         return match.params.slug || null
     }
-
     create_new_article() {
         // Create new placeholder article, then open editor
         let {cookies} = this.props
@@ -373,6 +372,8 @@ class AuthorPage extends React.Component {
     }
 
     render() {
+console.log(this.props)
+console.log(this.state)
         let {classes, embedded, user_session} = this.props
         let {articles, author, edit_author_modal_open, edit_article_modal_open,
             editing_article_id, popperAnchorEl, author_creator_showing,
@@ -456,7 +457,9 @@ class AuthorPage extends React.Component {
                                     <AuthorLinks links={author.profile_urls} />
                                 </div>
                                     {search_filter}
-                                    <LongMenu/>
+                                    <span hidden={!editable}>
+                                         <LongMenu articlesIds={article_ids} addArticle={this.create_new_article} linkArticle={this.link_existing_article} />
+                                    </span>
                                 </div>
                                 :
                                 <Grid container alignItems="center" justify="space-between">


### PR DESCRIPTION
Fix in the  author page improvements #103 

move article list actions to a (vertical) 3-dot more icon menu, horizontally aligned w/ Filter articles box (see mockup; only displayed for users w/ proper permissions for these actions, i.e., admins or users own author page) 80 points
- for "LINK EXISTING ARTICLE" menu item, it's OK that article selector component opens just below menu item wherever it happens to be (just like how it currently opens below the "LINK EXISTING ARTICLE" button)
- ensure proper (vertical) spacing between Filter articles box and author info URLs (this applies to non-logged-in users too)

It includes AuthorPageActions.jsx functional component, but it's not applied inside the AuthorPage. AuthorPageActions component needs more work. Ideally, we should have all author page actions inside AuthorPageActions functional component. Finally, the solution is only in the AuthorPage.jsx.
