### PR TITLE
Fullscreen on article page loading

### DIFF
--- a/src/components/ViewEmbeddedContentButton.jsx
+++ b/src/components/ViewEmbeddedContentButton.jsx
@@ -99,6 +99,7 @@ export default function ViewEmbeddedContentButton({ iconStyle, mediaType, style,
     }
 
     function toggle_viewer(url) {
+        mediaType === 'pdf' ? url = url.replace('#view=FitH', '') : null
         if (view_url.url === url) {
             view_url.clear_url()
         } else {

--- a/src/components/ViewEmbeddedContentButton.jsx
+++ b/src/components/ViewEmbeddedContentButton.jsx
@@ -16,65 +16,66 @@ const useStyles = makeStyles(theme => ({
 }))
 
 
-
-function url_contains(url, strings) {
-    return some(strings, (string) => includes(url, string))
-}
-
-
-function pdf_url_is_valid(url) {
-    const valid_urls = ['open.lnu.se/index.php', 'readcube.com/articles']
-    const denied_urls = [
-        'academia.edu.documents',
-        'core.ac.uk',
-        'github.com',
-        'psycnet.apa.org/fulltext',
-        'researchgate.net',
-    ]
-
-    if (url_contains(url, denied_urls)) return false
-    if (url_contains(url, valid_urls)) return true
-
-    return endsWith(url, '.pdf')
-}
-
-
-function html_url_is_valid(url) {
-    const valid_urls = ['github.io', 'distill.pub']
-    if (includes(url, 'frontiersin.org/articles') && endsWith(url, 'full')) return true
-    if (url_contains(url, valid_urls)) return true
-    return endsWith(url, '.html')
-}
-
-
-function preprint_url_is_valid(url) {
-    const denied_urls = ['github.com', 'psycnet.apa.org/fulltext', 'academia.edu.documents']
-    if (url_contains(url, denied_urls)) return false
-
-    return endsWith(url, '.pdf')
-}
-
-
-function url_is_valid(url, mediaType) {
-    // We can only embed content from https URLs
-    if (!startsWith(url, 'https')) return false
-
-    switch(mediaType) {
-        case 'pdf':
-            return pdf_url_is_valid(url)
-
-        case 'html':
-            return html_url_is_valid(url)
-
-        case 'preprint':
-            return preprint_url_is_valid(url)
-
-        default:
-            return false
-
+export function is_url_valid(url, mediaType) {
+    function url_contains(url, strings) {
+        return some(strings, (string) => includes(url, string))
     }
-}
 
+
+    function pdf_url_is_valid(url) {
+        const valid_urls = ['open.lnu.se/index.php', 'readcube.com/articles']
+        const denied_urls = [
+            'academia.edu.documents',
+            'core.ac.uk',
+            'github.com',
+            'psycnet.apa.org/fulltext',
+            'researchgate.net',
+        ]
+
+        if (url_contains(url, denied_urls)) return false
+        if (url_contains(url, valid_urls)) return true
+
+        return endsWith(url, '.pdf')
+    }
+
+
+    function html_url_is_valid(url) {
+        const valid_urls = ['github.io', 'distill.pub']
+        if (includes(url, 'frontiersin.org/articles') && endsWith(url, 'full')) return true
+        if (url_contains(url, valid_urls)) return true
+        return endsWith(url, '.html')
+    }
+
+
+    function preprint_url_is_valid(url) {
+        const denied_urls = ['github.com', 'psycnet.apa.org/fulltext', 'academia.edu.documents']
+        if (url_contains(url, denied_urls)) return false
+
+        return endsWith(url, '.pdf')
+    }
+
+
+    function url_is_valid(url, mediaType) {
+        // We can only embed content from https URLs
+        if (!startsWith(url, 'https')) return false
+
+        switch(mediaType) {
+            case 'pdf':
+                return pdf_url_is_valid(url)
+
+            case 'html':
+                return html_url_is_valid(url)
+
+            case 'preprint':
+                return preprint_url_is_valid(url)
+
+            default:
+                return false
+
+        }
+    }
+    return url_is_valid(url, mediaType)
+}
 
 export default function ViewEmbeddedContentButton({ iconStyle, mediaType, style, url }) {
     const classes = useStyles()
@@ -91,7 +92,7 @@ export default function ViewEmbeddedContentButton({ iconStyle, mediaType, style,
     const lessThanXl = useMediaQuery('(max-width:1499px)')
     if (lessThanXl) return null
 
-    if (!url_is_valid(url, mediaType)) return null
+    if (!is_url_valid(url, mediaType)) return null
 
     if (mediaType === 'pdf') {
         url += '#view=FitH'

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -16,6 +16,7 @@ import { json_api_req, simple_api_req } from '../util/util.jsx'
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import { withStyles } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 const styles = theme => ({
   root: {
     paddingTop: 20,
@@ -37,6 +38,11 @@ const withViewURL = (Component) => {
     return <Component view_url={view_url} {...props} />
   }
   return WrappedComponent
+}
+
+const withMediaQuery = (...args) => Component => props => {
+  const mediaQuery = useMediaQuery(...args);
+  return <Component media_query={mediaQuery} {...props} />;
 }
 
 class ArticlePage extends React.PureComponent {
@@ -113,23 +119,29 @@ class ArticlePage extends React.PureComponent {
     const pdf_url = this.state.article.pdf_url
     const html_url = this.state.article.html_url
     const preprint_url = this.state.article.preprint_url
-    if (is_url_valid(html_url, 'html')) {
-      view_url.update_url(html_url)
+    if (!this.props.media_query) {
+      if (is_url_valid(html_url, 'html')) {
+        view_url.update_url(html_url)
+      }
+
+      else if (is_url_valid(pdf_url, 'pdf') && !is_url_valid(html_url)) {
+        view_url.update_url(pdf_url) 
+      }
+
+      else if (is_url_valid(preprint_url, 'preprint') && !is_url_valid(html_url, 'html') && !is_url_valid(pdf_url, 'pdf')) {
+        view_url.update_url(preprint_url) 
+      }
+
+      else {
+        return null
+      } 
     }
 
-    else if (is_url_valid(pdf_url, 'pdf') && !is_url_valid(html_url)) {
-      view_url.update_url(pdf_url) 
-      }
-
-    else if (is_url_valid(preprint_url, 'preprint') && !is_url_valid(html_url, 'html') && !is_url_valid(pdf_url, 'pdf')) {
-      view_url.update_url(preprint_url) 
-      }
-
     else {
-      return null
-    } 
-    this.setState({flscreen_on_load: false})    
-  }
+      null
+    }
+  this.setState({flscreen_on_load: false})    
+}
 
   render() {
     const { classes, show_date, user_session} = this.props
@@ -175,4 +187,4 @@ class ArticlePage extends React.PureComponent {
   }
 }
 
-export default withViewURL(withRouter(withCookies(withStyles(styles)(ArticlePage))))
+export default withMediaQuery('(max-width:1499px)')(withViewURL(withRouter(withCookies(withStyles(styles)(ArticlePage)))))

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -6,6 +6,8 @@ import ArticleActions from '../components/ArticleActions.jsx';
 import ArticleEditor from '../components/ArticleEditor.jsx';
 import ArticleContent from '../components/ArticleContent.jsx';
 import Loader from '../components/shared/Loader.jsx';
+import { is_url_valid } from '../components/ViewEmbeddedContentButton.jsx'
+import { ViewURL } from '../components/EmbeddedViewer.jsx';
 
 import C from '../constants/constants';
 
@@ -14,8 +16,6 @@ import { json_api_req, simple_api_req } from '../util/util.jsx'
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import { withStyles } from '@material-ui/core/styles';
-
-
 const styles = theme => ({
   root: {
     paddingTop: 20,
@@ -30,6 +30,14 @@ const styles = theme => ({
   },
 })
 
+// prepare HOC to apply ViewURL hook in the class component
+const withViewURL = (Component) => {
+  function WrappedComponent(props) {
+    let view_url = ViewURL.useContainer()
+    return <Component view_url={view_url} {...props} />
+  }
+  return WrappedComponent
+}
 
 class ArticlePage extends React.PureComponent {
   constructor(props) {
@@ -38,6 +46,7 @@ class ArticlePage extends React.PureComponent {
       article: null,
       loading: true,
       edit_article_modal_open: false,
+      flscreen_on_load: true,
     }
 
     this.open_article_editor = this.toggle_article_editor.bind(this, true)
@@ -62,6 +71,9 @@ class ArticlePage extends React.PureComponent {
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.match.params.id !== this.state.current_id) {
       this.fetch_article()
+    }
+    if (this.state.flscreen_on_load) {
+      this.load_flscreen()
     }
   }
 
@@ -96,6 +108,29 @@ class ArticlePage extends React.PureComponent {
     }
   }
 
+  load_flscreen() {
+    const view_url = this.props.view_url
+    const pdf_url = this.state.article.pdf_url
+    const html_url = this.state.article.html_url
+    const preprint_url = this.state.article.preprint_url
+    if (is_url_valid(html_url, 'html')) {
+      view_url.update_url(html_url)
+    }
+
+    else if (is_url_valid(pdf_url, 'pdf') && !is_url_valid(html_url)) {
+      view_url.update_url(pdf_url) 
+      }
+
+    else if (is_url_valid(preprint_url, 'preprint') && !is_url_valid(html_url, 'html') && !is_url_valid(pdf_url, 'pdf')) {
+      view_url.update_url(preprint_url) 
+      }
+
+    else {
+      return null
+    } 
+    this.setState({flscreen_on_load: false})    
+  }
+
   render() {
     const { classes, show_date, user_session} = this.props
     const {
@@ -112,7 +147,6 @@ class ArticlePage extends React.PureComponent {
           :
             <div className="ArticleWithActions">
               <div className="Article">
-
                 <Card className={classes.card}>
                   <CardContent className={classes.cardContent}>
                     <ArticleContent
@@ -141,4 +175,4 @@ class ArticlePage extends React.PureComponent {
   }
 }
 
-export default withRouter(withCookies(withStyles(styles)(ArticlePage)))
+export default withViewURL(withRouter(withCookies(withStyles(styles)(ArticlePage))))


### PR DESCRIPTION
Update in #105
"activate full-screen mode on ARTICLE PAGE page load (if full-text embedabble content is available) 

example: https://curatescience.org/app/article/12 : this page should automatically display the full-text embed viewer panel because it does have one available (https://open.lnu.se/index.php/metapsychology/article/view/843/1835), so it should look like this on page load:
![githib](https://user-images.githubusercontent.com/43213967/90505497-03c50480-e153-11ea-938f-0ebd5f988c8d.png)
f more than 1 full-text embed link is available, show HTML as top priority, then PDF, and then Preprint as last resort (though extremely rare to have all 3)"

I used hooks as HOCs to apply logic from functional components made with hooks in the class-based ArticlePage.jsx component