### PR TITLE
Fixes to article page

### DIFF
--- a/src/components/ViewEmbeddedContentButton.jsx
+++ b/src/components/ViewEmbeddedContentButton.jsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { Button, Icon, IconButton } from '@material-ui/core';
 
 import { ViewURL } from './EmbeddedViewer.jsx';
-
+import { Context } from '../pages/ArticlePage.jsx'
 
 const useStyles = makeStyles(theme => ({
     button: {
@@ -106,7 +106,8 @@ export default function ViewEmbeddedContentButton({ iconStyle, mediaType, style,
             view_url.update_url(url)
         }
     }
-
+    const context = React.useContext(Context);
+    if (context.is_article_page) return null
     return (
         <Button style={style} onClick={() => toggle_viewer(url)} className={classes.button} title="View in embedded viewer">
             <Icon style={iconStyle}>zoom_out_map</Icon>

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -45,6 +45,8 @@ const withMediaQuery = (...args) => Component => props => {
   return <Component media_query={mediaQuery} {...props} />;
 }
 
+export const Context = React.createContext({is_article_page: false})
+
 class ArticlePage extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -52,7 +54,8 @@ class ArticlePage extends React.PureComponent {
       article: null,
       loading: true,
       edit_article_modal_open: false,
-      flscreen_on_load: true,
+      viewer_on_load: true,
+      article_change : false,
     }
 
     this.open_article_editor = this.toggle_article_editor.bind(this, true)
@@ -77,10 +80,14 @@ class ArticlePage extends React.PureComponent {
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.match.params.id !== this.state.current_id) {
       this.fetch_article()
+      this.setState({article_change: true})
     }
-    if (this.state.flscreen_on_load) {
+    if (this.state.viewer_on_load) {
       this.load_flscreen()
     }
+    else if (this.state.article_change) {
+      this.load_flscreen()
+    } 
   }
 
   fetch_article() {
@@ -115,11 +122,12 @@ class ArticlePage extends React.PureComponent {
   }
 
   load_flscreen() {
-    const view_url = this.props.view_url
-    const pdf_url = this.state.article.pdf_url
-    const html_url = this.state.article.html_url
-    const preprint_url = this.state.article.preprint_url
     if (!this.props.media_query) {
+      const view_url = this.props.view_url
+      const pdf_url = this.state.article.pdf_url
+      const html_url = this.state.article.html_url
+      const preprint_url = this.state.article.preprint_url
+
       if (is_url_valid(html_url, 'html')) {
         view_url.update_url(html_url)
       }
@@ -138,9 +146,9 @@ class ArticlePage extends React.PureComponent {
     }
 
     else {
-      null
+      return null
     }
-  this.setState({flscreen_on_load: false})    
+  this.setState({viewer_on_load: false})    
 }
 
   render() {
@@ -157,6 +165,7 @@ class ArticlePage extends React.PureComponent {
         { loading ?
         <Loader />
           :
+          <Context.Provider value={{ is_article_page: true }}>
             <div className="ArticleWithActions">
               <div className="Article">
                 <Card className={classes.card}>
@@ -180,6 +189,7 @@ class ArticlePage extends React.PureComponent {
                 onClose={this.close_article_editor}
               />
             </div>
+          </Context.Provider>
 
         }
       </div>


### PR DESCRIPTION
Remove 'ViewEmbeddedContent' button on article page loading, fix the issue with displaying embedded viewer on article page loading when transitioned from article page to article page through the search box.

I used React's Context to pass props (is_article_page) between ArticlePage.jsx parent component and ViewEmbeddedContentButton.jsx child component without affecting components that are in between them. 

