### PR TITLE
Remove top bar in an embedded viewer

### DIFF
--- a/src/components/EmbeddedViewer.jsx
+++ b/src/components/EmbeddedViewer.jsx
@@ -4,7 +4,7 @@ import { createContainer } from 'unstated-next'
 
 import { concat } from 'lodash'
 import { makeStyles } from '@material-ui/styles';
-import { Button, Icon, IconButton } from '@material-ui/core'
+import { Button, Icon } from '@material-ui/core'
 
 import { TOPBAR_HEIGHT } from './TopBar.jsx';
 
@@ -13,11 +13,6 @@ const useStyles = makeStyles(theme => ({
         [theme.breakpoints.down('lg')]: {
             display: 'none',
         }
-    },
-    viewerTopBar: {
-        background: '#333',
-        width: '100%',
-        textAlign: 'right',
     },
 }))
 
@@ -106,11 +101,6 @@ export default withRouter(function EmbeddedViewer({ history }) {
 
     return (
         <div className={classes.viewer} style={style}>
-            <div className={classes.viewerTopBar}> 
-                <IconButton onClick={closeViewer} title="Close embedded viewer" style={{ color: '#999' }}>
-                    <Icon>close</Icon>
-                </IconButton>
-            </div>
             <iframe style={{height: '100%', width: '100%', border: 'solid 1px', flex: 1}} src={view_url.url}></iframe>
         </div>
     )


### PR DESCRIPTION
Remove top bar in an embedded viewer.

I guess that we should add some space or padding between the embedded viewer and nav bar of the app. What do you think?