### PR TITLE
Search results/embed viewer fix: centering issue

### DIFF
--- a/src/pages/SearchResults.jsx
+++ b/src/pages/SearchResults.jsx
@@ -24,7 +24,6 @@ import { withStyles } from '@material-ui/core/styles';
 const styles = theme => ({
   root: {
     paddingTop: 20,
-    width: C.COL_WIDTH,
     margin: '0 auto',
   },
   header: {
@@ -212,7 +211,7 @@ class SearchResultsPage extends React.Component {
           }
         </Grid>
 
-        <div style={{width: C.CARD_COL_WIDTH}}>
+        <div style={{width: C.CARD_COL_WIDTH, margin: '0 auto'}}>
           { 
             searching ?
             <Loader/> :


### PR DESCRIPTION
Fix from the full-screen mode enhancements #95 

"search results page improvements: center article list div in left-panel, which will fix centering issue (same issue is currently affecting article page, see #64 ) and will fix the issue whereby the filter/sort buttons are being clipped on the right (see [screenshot](https://user-images.githubusercontent.com/4512335/76031693-36ad7000-5f06-11ea-83df-61bf88a806e1.png))"

I removed the column width constant and centered the article list div. 